### PR TITLE
Fix parsing

### DIFF
--- a/lib/csql.rb
+++ b/lib/csql.rb
@@ -24,7 +24,7 @@ module CSQL
       if column == "*"
         columns = File.open(@filepath,'r').gets.chomp.split(',').map{|c|c.strip}
       else
-        columns = column.chomp.split(',').map{|c|c.gsub('`','').split(/as|AS/).last.strip}
+        columns = column.chomp.split(',').map{|c|c.gsub('`','').split(/ (as|AS) /).last.strip}
       end
       return result.chomp.split("\n").map{|r|
         data = r.split(",")

--- a/lib/csql.rb
+++ b/lib/csql.rb
@@ -12,7 +12,7 @@ module CSQL
 
     def execute query
       begin
-        modified_query = query.gsub(/csv/, @filepath)
+        modified_query = query.gsub(/ from csv /, " from #{@filepath} ")
         result,err,process = Open3.capture3("q -H -d \',\' \'#{modified_query}\'")
         if err != ""
           raise CSQLException.new(err)


### PR DESCRIPTION
Added tiny fixes to regular expressions, to prevent #gsub returning wrong result when column specifications of SQL statement includes the word as or csv. (For example: last)

(すみません、英語に自信ないので)
カラム名に as が入っていたり (last とか) 、 csv という文字列が含まれていると置換が想定通りにならないので、正規表現のマッチングをちょっとだけ厳しく修正してみました
